### PR TITLE
Fix action button text in tooltips related to registration open and closing times

### DIFF
--- a/espresso-calendar.php
+++ b/espresso-calendar.php
@@ -618,7 +618,7 @@ class EE_Calendar {
 			$end = strtotime( $event->end_date . ' ' . $event->end_time );
 			$events[ $cntr ]['event_days'] = max( ceil(( $end - $start ) / ( 60*60*24 )), 1 );
 
-			$expired = ($events[ $cntr ]['end'] < date('c') || $events[ $cntr ]['reg_end'] < date('c')) && $event->event_status != 'O' ? TRUE : FALSE;
+			$expired = ($events[ $cntr ]['end'] < current_time('c') || $events[ $cntr ]['reg_end'] < current_time('c')) && $event->event_status != 'O' ? TRUE : FALSE;
 			if ( $expired ) {
 				$events[ $cntr ]['className'] = 'expired';
 			} else {
@@ -626,7 +626,7 @@ class EE_Calendar {
 			}
 			
 			//Make sure registration is open 
-			$not_open = $events[ $cntr ]['reg_start'] > date('c') ? TRUE : FALSE;
+			$not_open = $events[ $cntr ]['reg_start'] > current_time('c') ? TRUE : FALSE;
 			if ( $not_open ) {
 				$events[ $cntr ]['className'] = 'not-open';
 			}


### PR DESCRIPTION
This is related to the Datetime component improvements in WordPress 5.3 and the fixes in EE3 core. 

## How this has been tested:

Set the appropriate timezone for your locale in WP > Settings > General
Set the calendar to display tooltips
1) Set an event so it's open for registration
2) Set an event so it's not yet open for registration
3) Set an event so registration end date has passed

Check the calendar to make sure each tooltip contains the correct button text for the event.
1) Register Now
2) Registration Not Open
3) Registration Closed