### PR TITLE
Fix issue where today's events drop off the calendar early (timezone related)

### DIFF
--- a/espresso-calendar.php
+++ b/espresso-calendar.php
@@ -454,7 +454,7 @@ class EE_Calendar {
 		remove_shortcode('gallery');
 		// get calendar options
 		$this->_calendar_options = $this->_get_calendar_options();
-		$today = date( 'Y-m-d' );
+		$today = current_time( 'Y-m-d' );
 		$month = date('m' );
 		$year = date('Y' );
 		$start_date = isset( $_REQUEST['start_date'] ) ? date( 'Y-m-d', absint( $_REQUEST['start_date'] )) : date('Y-m-d', mktime( 0, 0, 0, $month, 1, $year ));


### PR DESCRIPTION
This goes back to the WP 5.3 fixes where EE3 is no longer doing_it_wrong() with date_default_timezone_set(). Now we need to use current_time() wherever we do date comparisons. In this case, calendar events were dropping off the calendar too early (or maybe too late) depending on the site's timezone.

To test, with this branch activated, add an event that will start/end sometime today. It should display on the calendar when `show_expired=false` (or the default shortcode). Yesterday's events should not display.